### PR TITLE
make the default number of GPUs align with the README file

### DIFF
--- a/configs/default_config.yaml
+++ b/configs/default_config.yaml
@@ -7,7 +7,7 @@ exp_path: ''
 
 env:
   device: 'cuda:0'
-  gpus: [0, 1]
+  gpus: [0]
   num_workers: 32
 
 model:


### PR DESCRIPTION
The current behaviour gives an error on # of GPUs not aligning with the config when running the default single-GPU command from the README. This just modifies the default config file to avoid that error.